### PR TITLE
improve nbplayers rank adjustment formula

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -96,7 +96,7 @@ def create_item_data(json_data):
         for pokemon in match["pokemons"]:
             for item in pokemon["items"]:
                 item_stats[item]["count"] += 1
-                item_stats[item]["rank"] += match["rank"] * 8 / nbPlayers
+                item_stats[item]["rank"] += 1 + (match["rank"] - 1) * 7 / (nbPlayers - 1)
                 name = pokemon["name"]
                 if name == "CHERRUBI":
                     name = "CHERUBI"
@@ -127,7 +127,7 @@ def create_pokemon_data(json_data):
             name = pokemon["name"]
             if name == "CHERRUBI":
                 name = "CHERUBI"
-            pokemon_stats[name]["rank"] += match["rank"] * 8 / nbPlayers
+            pokemon_stats[name]["rank"] += 1 + (match["rank"] - 1) * 7 / (nbPlayers - 1)
             pokemon_stats[name]["item_count"] += len(pokemon["items"])
             pokemon_stats[name]["count"] += 1
             for item in pokemon["items"]:
@@ -213,7 +213,7 @@ def create_pokemon_data_elo_threshold(json_data):
                     name = pokemon["name"]
                     if name == "CHERRUBI":
                         name = "CHERUBI"
-                    pokemon_stats[name]["rank"] += match["rank"] * 8 / nbPlayers
+                    pokemon_stats[name]["rank"] += 1 + (match["rank"] - 1) * 7 / (nbPlayers - 1)
                     pokemon_stats[name]["item_count"] += len(pokemon["items"])
                     pokemon_stats[name]["count"] += 1
                     for item in pokemon["items"]:


### PR DESCRIPTION
The current formula used to adjust rank on games with less than 8 players was not precise enough

`rank * 8/nbPlayers`

For a 2 players game, this means 1st gets rank 4 and 2nd gets rank 8, so an average rank of 6 instead of the expected 4.5

The expected adjusted rank should be:
2 players: 1 2 → 1 8
3 players;:1 2 3 → 1 4.5 8
4 players: 1 2 3 4 → 1 3.33 5.66 8

That is this formula:

`1 + (7*(rank-1)/(nbPlayers-1))`

this way we have a consistent 4.5 average for all number of players